### PR TITLE
Changes from `feature/colorful-terminal` to `develop`

### DIFF
--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -26,6 +26,41 @@ pub enum Style {
     Italic,
 }
 
+/// A struct that allows you to print styled and colored text in the terminal.
+/// This example demonstrates how you can use the `Colorful` struct for adding colors and styles.
+///
+/// # Examples
+///
+/// Basic usage of the `Colorful` struct for various text styles and colors.
+///
+/// ```rust
+/// use katana::colorful::{Color, Colorful, Style};
+///
+/// fn main() {
+///     let no_style = Colorful::new("no_style");
+///
+///     // default style (no style, no colors)
+///     println!("{}", no_style);
+///
+///     // red
+///     let red_text = Colorful::new("red_text")
+///         .set_foreground(Color::Red);
+///     println!("{}", red_text);
+///
+///     // blue on red
+///     let blue_on_red = Colorful::new("blue_on_red")
+///         .set_background(Color::Red)
+///         .set_foreground(Color::Blue);
+///     println!("{}", blue_on_red);
+///
+///     // green on black, bold
+///     let hacker_style = Colorful::new("hacker_style")
+///         .set_background(Color::Black)
+///         .set_foreground(Color::Green)
+///         .set_style(Style::Bold);
+///     println!("{}", hacker_style);
+/// }
+/// ```
 pub struct Colorful {
     text: String, // itself
     style: Option<Style>,

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -7,6 +7,8 @@
     https://jvns.ca/blog/2024/10/01/terminal-colours/
  */
 
+use std::env;
+
 pub enum Color {
     Black,
     White,
@@ -59,5 +61,33 @@ impl Colorful {
 
     pub fn set_background() {
         //
+    }
+
+    pub fn is_colors_supported() -> bool {
+        // explicitly disable colors
+        if env::var("NO_COLOR").is_ok() {
+            return false;
+        }
+
+        // only valid for unix shell
+        // https://www.baeldung.com/linux/terminal-colors#3-term-variable
+        if let Ok(term) = env::var("TERM") {
+            // checking with dumb may not be the proper way but keep it for now
+            // https://stackoverflow.com/questions/2465425/how-do-i-determine-if-a-terminal-is-color-capable
+            if term == "dumb" {
+                return false;
+            }
+        }
+
+        #[cfg(windows)] {
+            use std::io::IsTerminal;
+            use std::io::stdout;
+            // only if Windows supports ANSI
+            if !stdout().is_terminal() {
+                return false;
+            }
+        }
+
+        true
     }
 }

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -13,17 +13,33 @@ use std::{env, fmt};
 pub enum Color {
     Default,
     Black,
-    White,
     Red,
     Green,
+    Yellow,
     Blue,
+    Magenta,
+    Cyan,
+    White,
+    BrightBlack,
+    BrightRed,
+    BrightGreen,
+    BrightYellow,
+    BrightBlue,
+    BrightMagenta,
+    BrightCyan,
+    BrightWhite,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub enum Style {
     Default,
     Bold,
+    Dim,
     Italic,
+    Underline,
+    Blink,
+    Reverse,
+    Hidden,
 }
 
 /// A struct that allows you to print styled and colored text in the terminal.
@@ -129,10 +145,21 @@ impl Colorful {
         let code = match color {
             Color::Default => 0,
             Color::Black => base,
-            Color::White => base + 7,
             Color::Red => base + 1,
             Color::Green => base + 2,
+            Color::Yellow => base + 3,
             Color::Blue => base + 4,
+            Color::Magenta => base + 5,
+            Color::Cyan => base + 6,
+            Color::White => base + 7,
+            Color::BrightBlack => base + 60,
+            Color::BrightRed => base + 61,
+            Color::BrightGreen => base + 62,
+            Color::BrightYellow => base + 63,
+            Color::BrightBlue => base + 64,
+            Color::BrightMagenta => base + 65,
+            Color::BrightCyan => base + 66,
+            Color::BrightWhite => base + 67,
         };
 
         format!("\x1b[{}m", code)
@@ -142,7 +169,12 @@ impl Colorful {
         let code = match style {
             Style::Default => 0,
             Style::Bold => 1,
+            Style::Dim => 2,
             Style::Italic => 3,
+            Style::Underline => 4,
+            Style::Blink => 5,
+            Style::Reverse => 7,
+            Style::Hidden => 8,
         };
 
         format!("\x1b[{}m", code)
@@ -207,20 +239,50 @@ pub trait Colored: fmt::Display {
         self.colored().background(color)
     }
 
+    fn default(&self) -> Colorful { self.colored().foreground(Color::Default) }
     fn black(&self) -> Colorful { self.colored().foreground(Color::Black) }
     fn red(&self) -> Colorful { self.colored().foreground(Color::Red) }
     fn green(&self) -> Colorful { self.colored().foreground(Color::Green) }
+    fn yellow(&self) -> Colorful { self.colored().foreground(Color::Yellow) }
     fn blue(&self) -> Colorful { self.colored().foreground(Color::Blue) }
+    fn magenta(&self) -> Colorful { self.colored().foreground(Color::Magenta) }
+    fn cyan(&self) -> Colorful { self.colored().foreground(Color::Cyan) }
     fn white(&self) -> Colorful { self.colored().foreground(Color::White) }
+    fn bright_black(&self) -> Colorful { self.colored().foreground(Color::BrightBlack) }
+    fn bright_red(&self) -> Colorful { self.colored().foreground(Color::BrightRed) }
+    fn bright_green(&self) -> Colorful { self.colored().foreground(Color::BrightGreen) }
+    fn bright_yellow(&self) -> Colorful { self.colored().foreground(Color::BrightYellow) }
+    fn bright_blue(&self) -> Colorful { self.colored().foreground(Color::BrightBlue) }
+    fn bright_magenta(&self) -> Colorful { self.colored().foreground(Color::BrightMagenta) }
+    fn bright_cyan(&self) -> Colorful { self.colored().foreground(Color::BrightCyan) }
+    fn bright_white(&self) -> Colorful { self.colored().foreground(Color::BrightWhite) }
 
+    fn default_background(&self) -> Colorful { self.colored().background(Color::Default) }
     fn black_background(&self) -> Colorful { self.colored().background(Color::Black) }
     fn red_background(&self) -> Colorful { self.colored().background(Color::Red) }
     fn green_background(&self) -> Colorful { self.colored().background(Color::Green) }
+    fn yellow_background(&self) -> Colorful { self.colored().background(Color::Yellow) }
     fn blue_background(&self) -> Colorful { self.colored().background(Color::Blue) }
+    fn magenta_background(&self) -> Colorful { self.colored().background(Color::Magenta) }
+    fn cyan_background(&self) -> Colorful { self.colored().background(Color::Cyan) }
     fn white_background(&self) -> Colorful { self.colored().background(Color::White) }
+    fn bright_black_background(&self) -> Colorful { self.colored().background(Color::BrightBlack) }
+    fn bright_red_background(&self) -> Colorful { self.colored().background(Color::BrightRed) }
+    fn bright_green_background(&self) -> Colorful { self.colored().background(Color::BrightGreen) }
+    fn bright_yellow_background(&self) -> Colorful { self.colored().background(Color::BrightYellow) }
+    fn bright_blue_background(&self) -> Colorful { self.colored().background(Color::BrightBlue) }
+    fn bright_magenta_background(&self) -> Colorful { self.colored().background(Color::BrightMagenta) }
+    fn bright_cyan_background(&self) -> Colorful { self.colored().background(Color::BrightCyan) }
+    fn bright_white_background(&self) -> Colorful { self.colored().background(Color::BrightWhite) }
 
+    fn default_style(&self) -> Colorful { self.colored().style(Style::Default) }
     fn bold(&self) -> Colorful { self.colored().style(Style::Bold) }
+    fn dim(&self) -> Colorful { self.colored().style(Style::Dim) }
     fn italic(&self) -> Colorful { self.colored().style(Style::Italic) }
+    fn underline(&self) -> Colorful { self.colored().style(Style::Underline) }
+    fn blink(&self) -> Colorful { self.colored().style(Style::Blink) }
+    fn reverse(&self) -> Colorful { self.colored().style(Style::Reverse) }
+    fn hidden(&self) -> Colorful { self.colored().style(Style::Hidden) }
 }
 
 // Implement Colored for all types that implement Display

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -103,4 +103,29 @@ impl Colorful {
 
         true
     }
+
+    pub fn get_ansi_color(color: Color, is_background: bool) -> String {
+        // @todo: add more color later
+        let base = if is_background { 40 } else { 30 };
+        let code = match color {
+            Color::Default => 0,
+            Color::Black => base,
+            Color::White => base + 7,
+            Color::Red => base + 1,
+            Color::Green => base + 2,
+            Color::Blue => base + 4,
+        };
+
+        format!("\x1b[{}m", code)
+    }
+
+    pub fn get_ansi_style(style: Style) -> String {
+        let code = match style {
+            Style::Default => 0,
+            Style::Bold => 1,
+            Style::Italic => 3,
+        };
+
+        format!("\x1b[{}m", code)
+    }
 }

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -44,20 +44,20 @@ pub enum Style {
 ///
 ///     // red
 ///     let red_text = Colorful::new("red_text")
-///         .set_foreground(Color::Red);
+///         .foreground(Color::Red);
 ///     println!("{}", red_text);
 ///
 ///     // blue on red
 ///     let blue_on_red = Colorful::new("blue_on_red")
-///         .set_background(Color::Red)
-///         .set_foreground(Color::Blue);
+///         .background(Color::Red)
+///         .foreground(Color::Blue);
 ///     println!("{}", blue_on_red);
 ///
 ///     // green on black, bold
 ///     let hacker_style = Colorful::new("hacker_style")
-///         .set_background(Color::Black)
-///         .set_foreground(Color::Green)
-///         .set_style(Style::Bold);
+///         .background(Color::Black)
+///         .foreground(Color::Green)
+///         .style(Style::Bold);
 ///     println!("{}", hacker_style);
 /// }
 /// ```
@@ -80,33 +80,17 @@ impl Colorful {
         }
     }
 
-    pub fn get_text(mut self) -> String {
-        self.text
-    }
-
-    pub fn set_style(mut self, style: Style) -> Self {
+    pub fn style(mut self, style: Style) -> Self {
         self.style = Some(style);
         self
     }
-
-    pub fn get_style(mut self) -> Option<Style> {
-        self.style
-    }
-
-    pub fn get_foreground(mut self) -> Option<Color> {
-        self.foreground
-    }
-
-    pub fn set_foreground(mut self, color: Color) -> Self {
+    
+    pub fn foreground(mut self, color: Color) -> Self {
         self.foreground = Some(color);
         self
     }
 
-    pub fn get_background(mut self) -> Option<Color> {
-        self.foreground
-    }
-
-    pub fn set_background(mut self, color: Color) -> Self {
+    pub fn background(mut self, color: Color) -> Self {
         self.background = Some(color);
         self
     }

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -26,8 +26,8 @@ pub enum Style {
 pub struct Colorful {
     text: String, // itself
     style: Option<Style>,
-    foreground: Option<Style>,
-    background: Option<Style>,
+    foreground: Option<Color>,
+    background: Option<Color>,
 }
 
 impl Colorful {
@@ -35,32 +35,35 @@ impl Colorful {
         //
     }
 
-    pub fn get_text() {
-        //
+    pub fn get_text(mut self) -> String {
+        self.text
     }
 
-    pub fn set_style() {
-        //
+    pub fn set_style(mut self, style: Style) -> Self {
+        self.style = Some(style);
+        self
     }
 
-    pub fn get_style() {
-        //
+    pub fn get_style(mut self) -> Some<Style> {
+        self.style
     }
 
-    pub fn get_foreground() {
-        //
+    pub fn get_foreground(mut self) -> Some<Color> {
+        self.foreground
     }
 
-    pub fn set_foreground() {
-        //
+    pub fn set_foreground(mut self, color: Color) -> Self {
+        self.foreground = Some(color);
+        self
     }
 
-    pub fn get_background() {
-        //
+    pub fn get_background(mut self) -> Some<Color> {
+        self.foreground.unwrap()
     }
 
-    pub fn set_background() {
-        //
+    pub fn set_background(mut self, color: Color) -> Self {
+        self.foreground = Some(color);
+        self
     }
 
     pub fn is_colors_supported() -> bool {

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -1,0 +1,63 @@
+/*
+    Why ? 'cause style and colored terminal output are more interesting and good-looking for users.
+    Link bellow are for better understanding of how its works.
+
+    https://chrisyeh96.github.io/2020/03/28/terminal-colors.html
+    https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences
+    https://jvns.ca/blog/2024/10/01/terminal-colours/
+ */
+
+pub enum Color {
+    Black,
+    White,
+    Red,
+    Green,
+    Blue,
+}
+
+pub enum Style {
+    Default,
+    Bold,
+    Italic,
+}
+
+pub struct Colorful {
+    text: String, // itself
+    style: Style,
+    foreground: Style,
+    background: Style,
+}
+
+impl Colorful {
+    pub fn new() {
+        //
+    }
+
+    pub fn get_text() {
+        //
+    }
+
+    pub fn set_style() {
+        //
+    }
+
+    pub fn get_style() {
+        //
+    }
+
+    pub fn get_foreground() {
+        //
+    }
+
+    pub fn set_foreground() {
+        //
+    }
+
+    pub fn get_background() {
+        //
+    }
+
+    pub fn set_background() {
+        //
+    }
+}

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -9,7 +9,9 @@
 
 use std::env;
 
+#[derive(Debug, Clone, Copy)]
 pub enum Color {
+    Default,
     Black,
     White,
     Red,
@@ -17,6 +19,7 @@ pub enum Color {
     Blue,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum Style {
     Default,
     Bold,

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -174,7 +174,22 @@ impl fmt::Display for Colorful {
     }
 }
 
-// Trait to add color methods to any type that implements Display
+/// A trait to add colored output capabilities to any type that implements Display.
+///
+/// # Examples
+///
+///  ```rust
+/// use katana::colorful::Colored;
+///
+/// fn main() {
+///     println!(
+///         "{}{}{}.",
+///         "Katana Colorful".black().white_background(),
+///         ": ".blue().red_background(),
+///         "the Hacker Way".green().black_background().bold(),
+///     );
+/// }
+///  ```
 pub trait Colored: fmt::Display {
     fn colored(&self) -> Colorful {
         Colorful::new(self)
@@ -191,6 +206,21 @@ pub trait Colored: fmt::Display {
     fn background(&self, color: Color) -> Colorful {
         self.colored().background(color)
     }
+
+    fn black(&self) -> Colorful { self.colored().foreground(Color::Black) }
+    fn red(&self) -> Colorful { self.colored().foreground(Color::Red) }
+    fn green(&self) -> Colorful { self.colored().foreground(Color::Green) }
+    fn blue(&self) -> Colorful { self.colored().foreground(Color::Blue) }
+    fn white(&self) -> Colorful { self.colored().foreground(Color::White) }
+
+    fn black_background(&self) -> Colorful { self.colored().background(Color::Black) }
+    fn red_background(&self) -> Colorful { self.colored().background(Color::Red) }
+    fn green_background(&self) -> Colorful { self.colored().background(Color::Green) }
+    fn blue_background(&self) -> Colorful { self.colored().background(Color::Blue) }
+    fn white_background(&self) -> Colorful { self.colored().background(Color::White) }
+
+    fn bold(&self) -> Colorful { self.colored().style(Style::Bold) }
+    fn italic(&self) -> Colorful { self.colored().style(Style::Italic) }
 }
 
 // Implement Colored for all types that implement Display

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -34,8 +34,15 @@ pub struct Colorful {
 }
 
 impl Colorful {
-    pub fn new() {
-        //
+    // https://doc.rust-lang.org/rust-by-example/generics/bounds.html
+    // https://www.youtube.com/watch?v=t25vayJ8LVg
+    pub fn new(text: &str) -> Self {
+        Self {
+            text: text.to_string(),
+            style: None,
+            foreground: None,
+            background: None,
+        }
     }
 
     pub fn get_text(mut self) -> String {

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -238,6 +238,13 @@ pub trait Colored: fmt::Display {
     fn background(&self, color: Color) -> Colorful {
         self.colored().background(color)
     }
+    
+    fn reset(&self) -> Colorful {
+        self.colored()
+            .default()
+            .default_background()
+            .default_background()
+    }
 
     fn default(&self) -> Colorful { self.colored().foreground(Color::Default) }
     fn black(&self) -> Colorful { self.colored().foreground(Color::Black) }

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -241,9 +241,9 @@ pub trait Colored: fmt::Display {
     
     fn reset(&self) -> Colorful {
         self.colored()
-            .default()
-            .default_background()
-            .default_background()
+            .default() // default foreground
+            .default_background() // default background
+            .default_style() // default style
     }
 
     fn default(&self) -> Colorful { self.colored().foreground(Color::Default) }

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -23,9 +23,9 @@ pub enum Style {
 
 pub struct Colorful {
     text: String, // itself
-    style: Style,
-    foreground: Style,
-    background: Style,
+    style: Option<Style>,
+    foreground: Option<Style>,
+    background: Option<Style>,
 }
 
 impl Colorful {

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -72,7 +72,7 @@ impl Colorful {
     }
 
     pub fn set_background(mut self, color: Color) -> Self {
-        self.foreground = Some(color);
+        self.background = Some(color);
         self
     }
 

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -173,3 +173,25 @@ impl fmt::Display for Colorful {
         write!(f, "{}", result)
     }
 }
+
+// Trait to add color methods to any type that implements Display
+pub trait Colored: fmt::Display {
+    fn colored(&self) -> Colorful {
+        Colorful::new(self)
+    }
+
+    fn style(&self, style: Style) -> Colorful {
+        self.colored().style(style)
+    }
+
+    fn foreground(&self, color: Color) -> Colorful {
+        self.colored().foreground(color)
+    }
+
+    fn background(&self, color: Color) -> Colorful {
+        self.colored().background(color)
+    }
+}
+
+// Implement Colored for all types that implement Display
+impl<T: fmt::Display> Colored for T {}

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -54,11 +54,11 @@ impl Colorful {
         self
     }
 
-    pub fn get_style(mut self) -> Some<Style> {
+    pub fn get_style(mut self) -> Option<Style> {
         self.style
     }
 
-    pub fn get_foreground(mut self) -> Some<Color> {
+    pub fn get_foreground(mut self) -> Option<Color> {
         self.foreground
     }
 
@@ -67,8 +67,8 @@ impl Colorful {
         self
     }
 
-    pub fn get_background(mut self) -> Some<Color> {
-        self.foreground.unwrap()
+    pub fn get_background(mut self) -> Option<Color> {
+        self.foreground
     }
 
     pub fn set_background(mut self, color: Color) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod response;
 pub mod server;
 pub mod templates;
 pub mod utils;
+pub mod colorful;
 
 pub struct Katana {
     pub config: Config,

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,6 +1,7 @@
 use std::io::Write;
 use crate::config::Config;
 use crate::utils::Utils;
+use crate::colorful::{Colored};
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 #[allow(dead_code)]
@@ -96,9 +97,21 @@ impl Logger {
         let _ = writer.write_all(log_message.as_bytes());
     }
 
+    fn colorful_log_level(level: LogLevel) -> String {
+        let colored = match level {
+            LogLevel::DEBUG => level.as_str().cyan().dim(),
+            LogLevel::INFO => level.as_str().green(),
+            LogLevel::WARN => level.as_str().yellow().bold(),
+            LogLevel::ERROR => level.as_str().red().bold(),
+        };
+
+        colored.to_string()
+    }
+
     fn build_log_message(level: LogLevel, message: &str) -> String {
         let at = Utils::log_datetime();
-        let level_str = level.as_str();
+        let level_binding = Self::colorful_log_level(level);
+        let level_str = level_binding.as_str();
         let log_message = format!("[{}] [{}] {}", at, level_str, message);
         log_message
     }


### PR DESCRIPTION
# Changes from `feature/colorful-terminal` to `develop`

## Commits Overview: 


- 9215585 **fix(colorful): add reset style missing for reset method in colorful.rs**
  > add comments to clearly identify what have been reset 
- 6118d07 **feat(): add colorful log levels for better readability in logger.rs**
- 3908889 **feat(colorful): add reset method to reset foreground, background and style to default**
- 0b7b7e9 **feat(colorful): add extended colors and styles support in colorful.rs**
- 7479026 **feat(colorful): add colors and styles methods to `Colored` trait in colorful.rs**
- fe76a42 **feat(colorful): add Colored trait for easier strings manipulation in colorful.rs**
- acf0c3c **refactor(colorful): rename setter methods and remove getters in colorful.rs**
  > getters are not relevant here as we don't really need them. we also have get_ansi_style and get_ansi_color that are enough for the job we are doing here.
- ea5c79d **docs(colorful): add usage examples to `Colorful` struct in colorful.rs**
- bb93f2a **fix(colorful): set background while calling set_background method in colorful.rs**
- ee202c7 **feat(colorful): implement `fmt::Display` for `Colorful` in colorful.rs**
- ea21bfa **feat(colorful): add ANSI color and style formatting methods to `Colorful` in colorful.rs**
- df4d279 **fix(colorful): correct return types from Some<T> to Option<T> in colorful.rs**
- 653402d **feat(colorful): basic implementation of new method on `Colorful` in colorful.rs**
- 9d8d005 **refactor(colorful): add Debug, Clone, and Copy traits to Style and Color enums in colorful.rs**
- d149f5e **feat(colorful): update `Colorful` struct, implement getter and setter for style, foreground and background in colorful.rs**
- 1e56238 **feat(colorful): add colors check method to colorful.rs**
- 6b3823e **refactor(colorful): update skeleton of colorful.rs**
  > as we can set one or many options (style, foreground, background), they should be optional.
- dc2d6e1 **feat(colorful): add skeleton for colorful.rs for styled terminal output**