### PR TITLE
Changes from `refactor/hashmap-key-value` to `develop`

### DIFF
--- a/src/keyval.rs
+++ b/src/keyval.rs
@@ -12,6 +12,10 @@ impl KeyVal {
         }
     }
 
+    pub fn map(&self) -> &HashMap<String, String> {
+        &self.map
+    }
+
     pub fn add(&mut self, key: String, value: String) -> Option<String> {
         self.map.insert(key, value)
     }
@@ -42,5 +46,13 @@ impl KeyVal {
 
     pub fn clear(&mut self) {
         self.map.clear();
+    }
+
+    pub fn iter(&self) -> std::collections::hash_map::Iter<String, String> {
+        self.map.iter()
+    }
+
+    pub fn iter_mut(&mut self) -> std::collections::hash_map::IterMut<String, String> {
+        self.map.iter_mut()
     }
 }

--- a/src/keyval.rs
+++ b/src/keyval.rs
@@ -1,0 +1,46 @@
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+pub struct KeyVal {
+    map: HashMap<String, String>,
+}
+
+impl KeyVal {
+    pub fn new() -> Self {
+        KeyVal {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn add(&mut self, key: String, value: String) -> Option<String> {
+        self.map.insert(key, value)
+    }
+
+    pub fn del(&mut self, key: &str) -> Option<String> {
+        self.map.remove(key)
+    }
+
+    pub fn exists(&self, key: &str) -> bool {
+        self.map.contains_key(key)
+    }
+
+    pub fn get(&self, key: &str) -> Option<&String> {
+        self.map.get(key)
+    }
+
+    pub fn get_mut(&mut self, key: &str) -> Option<&mut String> {
+        self.map.get_mut(key)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.map.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod server;
 pub mod templates;
 pub mod utils;
 pub mod colorful;
+pub mod keyval;
 
 pub struct Katana {
     pub config: Config,

--- a/src/server.rs
+++ b/src/server.rs
@@ -95,10 +95,7 @@ impl Server {
     }
 
     pub fn server_transformation(&self, response: &mut Response) {
-        // add to headers server name
-        response
-            .headers
-            .push(("Server".to_string(), Self::version()));
+        response.headers.add("Server".to_string(), Self::version());
     }
 
     pub fn method_handle(&self, response: &mut Response) {
@@ -115,23 +112,21 @@ impl Server {
             // do not return body
             response.body = Vec::new();
 
-            // headers
-            response
-                .headers
-                .push(("Date".to_string(), Utils::datetime_rfc_1123().to_string()));
-            response.headers.push((
+            response.headers.add("Date".to_string(), Utils::datetime_rfc_1123().to_string());
+            response.headers.add(
                 "Allow".to_string(),
                 HttpMethod::comma_separated(Self::SUPPORTED_HTTP_METHODS),
-            ));
+            );
             // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-            response
-                .headers
-                .push(("Access-Control-Allow-Origin".to_string(), "*".to_string()));
-            response.headers.push((
+            response.headers.add("Access-Control-Allow-Origin".to_string(), "*".to_string());
+            response.headers.add(
                 "Access-Control-Allow-Methods".to_string(),
                 HttpMethod::comma_separated(Self::SUPPORTED_HTTP_METHODS),
-            ));
-            // response.headers.push(("Access-Control-Allow-Headers".to_string(), "content-type, accept".to_string()));
+            );
+            // response.headers.add(
+            //     "Access-Control-Allow-Headers".to_string(), 
+            //     "content-type, accept".to_string()
+            // );
         }
 
         if response.request.method == HttpMethod::TRACE {
@@ -148,7 +143,7 @@ impl Server {
             // correct type
             response
                 .headers
-                .push(("Content-Type".to_string(), "message/http".to_string()));
+                .add("Content-Type".to_string(), "message/http".to_string());
 
             // new body
             let body = format!("\r\n{}", response.request.http_description());
@@ -156,7 +151,7 @@ impl Server {
             // new body length
             response
                 .headers
-                .push(("Content-Length".to_string(), body.len().to_string()));
+                .add("Content-Length".to_string(), body.len().to_string());
 
             // set new body
             response.body = body.into_bytes();
@@ -167,10 +162,10 @@ impl Server {
             response.body = Vec::new();
             // headers
             response.headers.clear();
-            response.headers.push((
+            response.headers.add(
                 "Allow".to_string(),
                 HttpMethod::comma_separated(Self::SUPPORTED_HTTP_METHODS),
-            ));
+            );
             // status
             response.status_code = HttpStatus::MethodNotAllowed;
         }


### PR DESCRIPTION
# Changes from `refactor/hashmap-key-value` to `develop`

## Commits Overview: 

- 94ab4fd **refactor(): replace Vec with KeyVal for efficiency and to support uniqueness**
  > impacted cookies, headers, queries, folders and files.
- 971477e **feat(): add map, iter, and iter_mut methods to KeyVal**
- 32797ff **feat(): add KeyVal struct in keyval.rs**