### PR TITLE
Changes from `refactor/basic-improvements` to `develop`

### DIFF
--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -1,11 +1,11 @@
 /*
-    Why ? 'cause style and colored terminal output are more interesting and good-looking for users.
-    Link bellow are for better understanding of how its works.
+   Why ? 'cause style and colored terminal output are more interesting and good-looking for users.
+   Link bellow are for better understanding of how its works.
 
-    https://chrisyeh96.github.io/2020/03/28/terminal-colors.html
-    https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences
-    https://jvns.ca/blog/2024/10/01/terminal-colours/
- */
+   https://chrisyeh96.github.io/2020/03/28/terminal-colors.html
+   https://stackoverflow.com/questions/4842424/list-of-ansi-color-escape-sequences
+   https://jvns.ca/blog/2024/10/01/terminal-colours/
+*/
 
 use std::{env, fmt};
 
@@ -100,7 +100,7 @@ impl Colorful {
         self.style = Some(style);
         self
     }
-    
+
     pub fn foreground(mut self, color: Color) -> Self {
         self.foreground = Some(color);
         self
@@ -127,9 +127,10 @@ impl Colorful {
             }
         }
 
-        #[cfg(windows)] {
-            use std::io::IsTerminal;
+        #[cfg(windows)]
+        {
             use std::io::stdout;
+            use std::io::IsTerminal;
             // only if Windows supports ANSI
             if !stdout().is_terminal() {
                 return false;
@@ -238,7 +239,7 @@ pub trait Colored: fmt::Display {
     fn background(&self, color: Color) -> Colorful {
         self.colored().background(color)
     }
-    
+
     fn reset(&self) -> Colorful {
         self.colored()
             .default() // default foreground
@@ -246,50 +247,134 @@ pub trait Colored: fmt::Display {
             .default_style() // default style
     }
 
-    fn default(&self) -> Colorful { self.colored().foreground(Color::Default) }
-    fn black(&self) -> Colorful { self.colored().foreground(Color::Black) }
-    fn red(&self) -> Colorful { self.colored().foreground(Color::Red) }
-    fn green(&self) -> Colorful { self.colored().foreground(Color::Green) }
-    fn yellow(&self) -> Colorful { self.colored().foreground(Color::Yellow) }
-    fn blue(&self) -> Colorful { self.colored().foreground(Color::Blue) }
-    fn magenta(&self) -> Colorful { self.colored().foreground(Color::Magenta) }
-    fn cyan(&self) -> Colorful { self.colored().foreground(Color::Cyan) }
-    fn white(&self) -> Colorful { self.colored().foreground(Color::White) }
-    fn bright_black(&self) -> Colorful { self.colored().foreground(Color::BrightBlack) }
-    fn bright_red(&self) -> Colorful { self.colored().foreground(Color::BrightRed) }
-    fn bright_green(&self) -> Colorful { self.colored().foreground(Color::BrightGreen) }
-    fn bright_yellow(&self) -> Colorful { self.colored().foreground(Color::BrightYellow) }
-    fn bright_blue(&self) -> Colorful { self.colored().foreground(Color::BrightBlue) }
-    fn bright_magenta(&self) -> Colorful { self.colored().foreground(Color::BrightMagenta) }
-    fn bright_cyan(&self) -> Colorful { self.colored().foreground(Color::BrightCyan) }
-    fn bright_white(&self) -> Colorful { self.colored().foreground(Color::BrightWhite) }
+    fn default(&self) -> Colorful {
+        self.colored().foreground(Color::Default)
+    }
+    fn black(&self) -> Colorful {
+        self.colored().foreground(Color::Black)
+    }
+    fn red(&self) -> Colorful {
+        self.colored().foreground(Color::Red)
+    }
+    fn green(&self) -> Colorful {
+        self.colored().foreground(Color::Green)
+    }
+    fn yellow(&self) -> Colorful {
+        self.colored().foreground(Color::Yellow)
+    }
+    fn blue(&self) -> Colorful {
+        self.colored().foreground(Color::Blue)
+    }
+    fn magenta(&self) -> Colorful {
+        self.colored().foreground(Color::Magenta)
+    }
+    fn cyan(&self) -> Colorful {
+        self.colored().foreground(Color::Cyan)
+    }
+    fn white(&self) -> Colorful {
+        self.colored().foreground(Color::White)
+    }
+    fn bright_black(&self) -> Colorful {
+        self.colored().foreground(Color::BrightBlack)
+    }
+    fn bright_red(&self) -> Colorful {
+        self.colored().foreground(Color::BrightRed)
+    }
+    fn bright_green(&self) -> Colorful {
+        self.colored().foreground(Color::BrightGreen)
+    }
+    fn bright_yellow(&self) -> Colorful {
+        self.colored().foreground(Color::BrightYellow)
+    }
+    fn bright_blue(&self) -> Colorful {
+        self.colored().foreground(Color::BrightBlue)
+    }
+    fn bright_magenta(&self) -> Colorful {
+        self.colored().foreground(Color::BrightMagenta)
+    }
+    fn bright_cyan(&self) -> Colorful {
+        self.colored().foreground(Color::BrightCyan)
+    }
+    fn bright_white(&self) -> Colorful {
+        self.colored().foreground(Color::BrightWhite)
+    }
 
-    fn default_background(&self) -> Colorful { self.colored().background(Color::Default) }
-    fn black_background(&self) -> Colorful { self.colored().background(Color::Black) }
-    fn red_background(&self) -> Colorful { self.colored().background(Color::Red) }
-    fn green_background(&self) -> Colorful { self.colored().background(Color::Green) }
-    fn yellow_background(&self) -> Colorful { self.colored().background(Color::Yellow) }
-    fn blue_background(&self) -> Colorful { self.colored().background(Color::Blue) }
-    fn magenta_background(&self) -> Colorful { self.colored().background(Color::Magenta) }
-    fn cyan_background(&self) -> Colorful { self.colored().background(Color::Cyan) }
-    fn white_background(&self) -> Colorful { self.colored().background(Color::White) }
-    fn bright_black_background(&self) -> Colorful { self.colored().background(Color::BrightBlack) }
-    fn bright_red_background(&self) -> Colorful { self.colored().background(Color::BrightRed) }
-    fn bright_green_background(&self) -> Colorful { self.colored().background(Color::BrightGreen) }
-    fn bright_yellow_background(&self) -> Colorful { self.colored().background(Color::BrightYellow) }
-    fn bright_blue_background(&self) -> Colorful { self.colored().background(Color::BrightBlue) }
-    fn bright_magenta_background(&self) -> Colorful { self.colored().background(Color::BrightMagenta) }
-    fn bright_cyan_background(&self) -> Colorful { self.colored().background(Color::BrightCyan) }
-    fn bright_white_background(&self) -> Colorful { self.colored().background(Color::BrightWhite) }
+    fn default_background(&self) -> Colorful {
+        self.colored().background(Color::Default)
+    }
+    fn black_background(&self) -> Colorful {
+        self.colored().background(Color::Black)
+    }
+    fn red_background(&self) -> Colorful {
+        self.colored().background(Color::Red)
+    }
+    fn green_background(&self) -> Colorful {
+        self.colored().background(Color::Green)
+    }
+    fn yellow_background(&self) -> Colorful {
+        self.colored().background(Color::Yellow)
+    }
+    fn blue_background(&self) -> Colorful {
+        self.colored().background(Color::Blue)
+    }
+    fn magenta_background(&self) -> Colorful {
+        self.colored().background(Color::Magenta)
+    }
+    fn cyan_background(&self) -> Colorful {
+        self.colored().background(Color::Cyan)
+    }
+    fn white_background(&self) -> Colorful {
+        self.colored().background(Color::White)
+    }
+    fn bright_black_background(&self) -> Colorful {
+        self.colored().background(Color::BrightBlack)
+    }
+    fn bright_red_background(&self) -> Colorful {
+        self.colored().background(Color::BrightRed)
+    }
+    fn bright_green_background(&self) -> Colorful {
+        self.colored().background(Color::BrightGreen)
+    }
+    fn bright_yellow_background(&self) -> Colorful {
+        self.colored().background(Color::BrightYellow)
+    }
+    fn bright_blue_background(&self) -> Colorful {
+        self.colored().background(Color::BrightBlue)
+    }
+    fn bright_magenta_background(&self) -> Colorful {
+        self.colored().background(Color::BrightMagenta)
+    }
+    fn bright_cyan_background(&self) -> Colorful {
+        self.colored().background(Color::BrightCyan)
+    }
+    fn bright_white_background(&self) -> Colorful {
+        self.colored().background(Color::BrightWhite)
+    }
 
-    fn default_style(&self) -> Colorful { self.colored().style(Style::Default) }
-    fn bold(&self) -> Colorful { self.colored().style(Style::Bold) }
-    fn dim(&self) -> Colorful { self.colored().style(Style::Dim) }
-    fn italic(&self) -> Colorful { self.colored().style(Style::Italic) }
-    fn underline(&self) -> Colorful { self.colored().style(Style::Underline) }
-    fn blink(&self) -> Colorful { self.colored().style(Style::Blink) }
-    fn reverse(&self) -> Colorful { self.colored().style(Style::Reverse) }
-    fn hidden(&self) -> Colorful { self.colored().style(Style::Hidden) }
+    fn default_style(&self) -> Colorful {
+        self.colored().style(Style::Default)
+    }
+    fn bold(&self) -> Colorful {
+        self.colored().style(Style::Bold)
+    }
+    fn dim(&self) -> Colorful {
+        self.colored().style(Style::Dim)
+    }
+    fn italic(&self) -> Colorful {
+        self.colored().style(Style::Italic)
+    }
+    fn underline(&self) -> Colorful {
+        self.colored().style(Style::Underline)
+    }
+    fn blink(&self) -> Colorful {
+        self.colored().style(Style::Blink)
+    }
+    fn reverse(&self) -> Colorful {
+        self.colored().style(Style::Reverse)
+    }
+    fn hidden(&self) -> Colorful {
+        self.colored().style(Style::Hidden)
+    }
 }
 
 // Implement Colored for all types that implement Display

--- a/src/colorful.rs
+++ b/src/colorful.rs
@@ -52,7 +52,7 @@ pub enum Style {
 /// ```rust
 /// use katana::colorful::{Color, Colorful, Style};
 ///
-/// fn main() {
+/// fn demo() {
 ///     let no_style = Colorful::new("no_style");
 ///
 ///     // default style (no style, no colors)

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ impl Config {
                 }
                 "--host" => {
                     if i + 1 < args.len() {
-                        host = args[i + 1].clone();
+                        host.clone_from(&args[i + 1]);
                         i += 1;
                     }
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::logger::{Logger, LogLevel};
+use crate::logger::{LogLevel, Logger};
 use std::env::args;
 use std::path::PathBuf;
 
@@ -67,9 +67,12 @@ impl Config {
                 }
                 "--log-level" => {
                     if i + 1 < args.len() {
-                        log_level = LogLevel::from_str(&args[i + 1].to_uppercase())
-                            .unwrap_or_else(|| {
-                                Logger::warn(format!("Invalid log level '{}', using default", args[i + 1]).as_str());
+                        log_level =
+                            LogLevel::from_str(&args[i + 1].to_uppercase()).unwrap_or_else(|| {
+                                Logger::warn(
+                                    format!("Invalid log level '{}', using default", args[i + 1])
+                                        .as_str(),
+                                );
                                 Self::DEFAULT_LOG_LEVEL
                             });
                         i += 1;

--- a/src/keyval.rs
+++ b/src/keyval.rs
@@ -5,6 +5,12 @@ pub struct KeyVal {
     map: HashMap<String, String>,
 }
 
+impl Default for KeyVal {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl KeyVal {
     pub fn new() -> Self {
         KeyVal {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,17 +4,17 @@ use crate::server::Server;
 use crate::templates::{Templates, TemplatesPage};
 use std::collections::HashMap;
 
+pub mod colorful;
 pub mod config;
 pub mod filetype;
 pub mod http;
+pub mod keyval;
 pub mod logger;
 pub mod request;
 pub mod response;
 pub mod server;
 pub mod templates;
 pub mod utils;
-pub mod colorful;
-pub mod keyval;
 
 pub struct Katana {
     pub config: Config,
@@ -38,9 +38,7 @@ impl Katana {
     pub fn start(&self) {
         self.show_banner();
         let server = Server::new(self.config.to_owned(), self.templates.to_owned());
-        Logger::info(
-            format!("Server starting on {}", server.addr_with_protocol()).as_str(),
-        );
+        Logger::info(format!("Server starting on {}", server.addr_with_protocol()).as_str());
         server.serve();
     }
 

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,7 +1,7 @@
-use std::io::Write;
+use crate::colorful::Colored;
 use crate::config::Config;
 use crate::utils::Utils;
-use crate::colorful::{Colored};
+use std::io::Write;
 
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 #[allow(dead_code)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,9 +1,9 @@
 use crate::http::{HttpMethod, HttpVersion};
+use crate::keyval::KeyVal;
 use crate::logger::Logger;
 use crate::server::Server;
 use std::io::{BufRead, BufReader, Read};
 use std::net::TcpStream;
-use crate::keyval::KeyVal;
 
 #[derive(Debug, Clone)]
 pub struct Request {
@@ -29,12 +29,14 @@ impl Request {
             return None;
         }
         let request_line = request_line.trim_end();
-        
+
         Logger::debug(format!("[Request] Request line: {}", request_line).as_str());
 
         let parts: Vec<&str> = request_line.split_whitespace().collect();
         if parts.len() < 3 {
-            Logger::warn(format!("[Request] Invalid request line format: {}", request_line).as_str());
+            Logger::warn(
+                format!("[Request] Invalid request line format: {}", request_line).as_str(),
+            );
             return None;
         }
 
@@ -42,9 +44,16 @@ impl Request {
         let raw_path = parts[1];
         let mut path = Self::decode_url(raw_path);
         let version = HttpVersion::from_str(&parts[2].replace("HTTP/", "")).unwrap();
-        
-        Logger::debug(format!("[Request] Method: {}, Path: {}, Version: {}", 
-            method.as_str(), path, version.as_str()).as_str());
+
+        Logger::debug(
+            format!(
+                "[Request] Method: {}, Path: {}, Version: {}",
+                method.as_str(),
+                path,
+                version.as_str()
+            )
+            .as_str(),
+        );
 
         let mut domain = String::new();
         let mut queries = KeyVal::new();
@@ -105,7 +114,9 @@ impl Request {
                 .find(|(key, _)| key.to_lowercase() == "content-length")
             {
                 if let Ok(content_length) = cl_value.trim().parse::<usize>() {
-                    Logger::debug(format!("[Request] Reading body with length: {}", content_length).as_str());
+                    Logger::debug(
+                        format!("[Request] Reading body with length: {}", content_length).as_str(),
+                    );
                     let mut buf = vec![0; content_length];
                     if let Err(e) = reader.read_exact(&mut buf) {
                         Logger::warn(&format!("[Request] Error reading body: {}", e));
@@ -116,11 +127,14 @@ impl Request {
                 }
             }
         } else {
-            Logger::warn(format!(
-                "[Request] Method '{}' on '{}' is disabled",
-                method.as_str(),
-                path.as_str()
-            ).as_str());
+            Logger::warn(
+                format!(
+                    "[Request] Method '{}' on '{}' is disabled",
+                    method.as_str(),
+                    path.as_str()
+                )
+                .as_str(),
+            );
         }
 
         Logger::debug("[Request] Request parsing completed successfully");

--- a/src/response.rs
+++ b/src/response.rs
@@ -75,6 +75,14 @@ impl Response {
     }
 
     fn serve_file(&mut self, root_path: &PathBuf, path: PathBuf) {
+        // normalize path separator based on system type
+        #[cfg(target_os = "windows")]
+            let path = path.to_str().unwrap().replace('/', "\\");
+        #[cfg(not(target_os = "windows"))]
+            let path = path.to_str().unwrap().replace('\\', "/");
+
+        let path = PathBuf::from(path);
+
         Logger::debug(format!("[Response] Attempting to serve file: {}", path.display()).as_str());
 
         let name = path.file_name().unwrap().to_string_lossy().to_string();

--- a/src/response.rs
+++ b/src/response.rs
@@ -122,7 +122,7 @@ impl Response {
                 // get file size without reading
                 let metadata = std::fs::metadata(&path).expect("Unable to read metadata"); // self.body.len().to_string()
                 let file_size = metadata.len();
-                let is_readable = metadata.permissions().readonly();
+                let is_readable = Utils::is_readable_from_metadata(metadata.clone());
 
                 if !is_readable {
                     Logger::error(format!("[Response] File not readable: {}", path.display()).as_str());

--- a/src/response.rs
+++ b/src/response.rs
@@ -80,9 +80,8 @@ impl Response {
     }
 
     fn serve_file(&mut self, root_path: &PathBuf, path: PathBuf) {
-        let path = PathBuf::from(path);
-
-        Logger::debug(format!("[Response] Attempting to serve file: {}", path.display()).as_str());
+        let display_path = Utils::path_prettifier(path.clone());
+        Logger::debug(format!("[Response] Attempting to serve file: {}", display_path).as_str());
 
         let name = path.file_name().unwrap().to_string_lossy().to_string();
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,15 +34,6 @@ impl Server {
         Logger::debug("[Server] Server is ready to accept connections");
 
         for stream in listener.incoming().flatten() {
-            Logger::debug(
-                format!(
-                    "[Server] New connection from {}",
-                    stream
-                        .peer_addr()
-                        .unwrap_or_else(|_| "[unknown]".parse().unwrap())
-                )
-                .as_str(),
-            );
             // spawn a new thread for each connection
             let config = self.config.clone();
             let templates = self.templates.clone();
@@ -55,7 +46,19 @@ impl Server {
         }
     }
 
+    pub fn log_source_ip(&self, stream: &TcpStream) {
+        Logger::debug(
+            format!(
+                "New connection from {}",
+                Utils::get_peer_ip(stream)
+            )
+            .as_str(),
+        );
+    }
+
     pub fn handle_request(&self, mut stream: TcpStream) {
+        self.log_source_ip(&stream);
+        
         if let Some(request) = Request::from_stream(&stream) {
             Logger::debug(
                 format!(

--- a/src/server.rs
+++ b/src/server.rs
@@ -205,7 +205,7 @@ impl Server {
             "\"{}\" {} {}",
             status_line,
             response.status_code.to_code(),
-            response._size,
+            response.size,
         );
         Logger::info(log_message);
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,27 +33,25 @@ impl Server {
         let listener = TcpListener::bind(self.addr().as_str()).unwrap();
         Logger::debug("[Server] Server is ready to accept connections");
 
-        for stream in listener.incoming() {
-            if let Ok(stream) = stream {
-                Logger::debug(
-                    format!(
-                        "[Server] New connection from {}",
-                        stream
-                            .peer_addr()
-                            .unwrap_or_else(|_| "[unknown]".parse().unwrap())
-                    )
-                    .as_str(),
-                );
-                // spawn a new thread for each connection
-                let config = self.config.clone();
-                let templates = self.templates.clone();
+        for stream in listener.incoming().flatten() {
+            Logger::debug(
+                format!(
+                    "[Server] New connection from {}",
+                    stream
+                        .peer_addr()
+                        .unwrap_or_else(|_| "[unknown]".parse().unwrap())
+                )
+                .as_str(),
+            );
+            // spawn a new thread for each connection
+            let config = self.config.clone();
+            let templates = self.templates.clone();
 
-                thread::spawn(move || {
-                    // create a new server instance for the thread with the necessary data
-                    let server = Server::new(config, templates);
-                    server.handle_request(stream);
-                });
-            }
+            thread::spawn(move || {
+                // create a new server instance for the thread with the necessary data
+                let server = Server::new(config, templates);
+                server.handle_request(stream);
+            });
         }
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,8 +35,15 @@ impl Server {
 
         for stream in listener.incoming() {
             if let Ok(stream) = stream {
-                Logger::debug(format!("[Server] New connection from {}", 
-                    stream.peer_addr().unwrap_or_else(|_| "[unknown]".parse().unwrap())).as_str());
+                Logger::debug(
+                    format!(
+                        "[Server] New connection from {}",
+                        stream
+                            .peer_addr()
+                            .unwrap_or_else(|_| "[unknown]".parse().unwrap())
+                    )
+                    .as_str(),
+                );
                 // spawn a new thread for each connection
                 let config = self.config.clone();
                 let templates = self.templates.clone();
@@ -52,8 +59,14 @@ impl Server {
 
     pub fn handle_request(&self, mut stream: TcpStream) {
         if let Some(request) = Request::from_stream(&stream) {
-            Logger::debug(format!("[Server] Request received: {} {}", 
-                request.method.as_str(), request.path).as_str());
+            Logger::debug(
+                format!(
+                    "[Server] Request received: {} {}",
+                    request.method.as_str(),
+                    request.path
+                )
+                .as_str(),
+            );
             self.handle_response(request, &mut stream);
         } else {
             Logger::warn("[Server] Failed to read request");
@@ -68,14 +81,19 @@ impl Server {
 
             let result = response.stream(stream.deref_mut());
             match result {
-                Ok(_response) => { 
-                    Logger::debug(format!("[Server] Response sent successfully: {}", 
-                        response.status_code.to_code()).as_str());
-                    Self::log_response(&response) 
-                },
+                Ok(_response) => {
+                    Logger::debug(
+                        format!(
+                            "[Server] Response sent successfully: {}",
+                            response.status_code.to_code()
+                        )
+                        .as_str(),
+                    );
+                    Self::log_response(&response)
+                }
                 Err(e) => {
                     Logger::error(format!("[Server] Stream error: {}", e).as_str());
-                },
+                }
             }
         } else {
             Logger::warn("[Server] Failed to create response");
@@ -112,19 +130,23 @@ impl Server {
             // do not return body
             response.body = Vec::new();
 
-            response.headers.add("Date".to_string(), Utils::datetime_rfc_1123().to_string());
+            response
+                .headers
+                .add("Date".to_string(), Utils::datetime_rfc_1123().to_string());
             response.headers.add(
                 "Allow".to_string(),
                 HttpMethod::comma_separated(Self::SUPPORTED_HTTP_METHODS),
             );
             // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
-            response.headers.add("Access-Control-Allow-Origin".to_string(), "*".to_string());
+            response
+                .headers
+                .add("Access-Control-Allow-Origin".to_string(), "*".to_string());
             response.headers.add(
                 "Access-Control-Allow-Methods".to_string(),
                 HttpMethod::comma_separated(Self::SUPPORTED_HTTP_METHODS),
             );
             // response.headers.add(
-            //     "Access-Control-Allow-Headers".to_string(), 
+            //     "Access-Control-Allow-Headers".to_string(),
             //     "content-type, accept".to_string()
             // );
         }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use crate::logger::Logger;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub enum TemplatesPage {
@@ -28,7 +28,13 @@ impl Templates {
     }
 
     pub fn from_enum(template_page: TemplatesPage) -> Option<String> {
-        Logger::debug(format!("[Templates] Loading template from enum: {:?}", template_page).as_str());
+        Logger::debug(
+            format!(
+                "[Templates] Loading template from enum: {:?}",
+                template_page
+            )
+            .as_str(),
+        );
         let templates = Self::load();
 
         let result = match template_page {
@@ -38,14 +44,22 @@ impl Templates {
         };
 
         if result.is_none() {
-            Logger::warn(format!("[Templates] Template not found for {:?}", template_page).as_str());
+            Logger::warn(
+                format!("[Templates] Template not found for {:?}", template_page).as_str(),
+            );
         }
         result
     }
 
     pub fn render(&self, template: TemplatesPage, params: HashMap<String, String>) -> String {
-        Logger::debug(format!("[Templates] Rendering template {:?} with {} parameters", 
-            template, params.len()).as_str());
+        Logger::debug(
+            format!(
+                "[Templates] Rendering template {:?} with {} parameters",
+                template,
+                params.len()
+            )
+            .as_str(),
+        );
 
         let mut content = match Self::from_enum(template) {
             Some(content) => content,
@@ -57,7 +71,9 @@ impl Templates {
 
         for (key, value) in params {
             if value.is_empty() {
-                Logger::debug(format!("[Templates] Skipping empty value for key: {}", key).as_str());
+                Logger::debug(
+                    format!("[Templates] Skipping empty value for key: {}", key).as_str(),
+                );
                 continue;
             }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -259,4 +259,15 @@ impl Utils {
 
         is_readable
     }
+
+    pub fn path_prettifier(path: PathBuf) -> String {
+        // use correct path separator based on system type for display purpose
+        #[cfg(target_os = "windows")]
+            let prettified = path.to_str().unwrap().replace('/', "\\");
+
+        #[cfg(not(target_os = "windows"))]
+            let prettified = path.to_str().unwrap().replace('\\', "/");
+
+        prettified
+    }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::fs::{self, ReadDir};
+use std::fs::{self, Metadata, ReadDir};
 use std::path::{Component, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -215,5 +215,26 @@ impl Utils {
         );
 
         datetime
+    }
+
+    pub fn is_readable(path: PathBuf) -> bool {
+        let metadata = fs::metadata(path).expect("Unable to read metadata");
+        Self::is_readable_from_metadata(metadata)
+    }
+
+    pub fn is_readable_from_metadata(metadata: Metadata) -> bool {
+        #[cfg(unix)]
+        let is_readable = {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = metadata.permissions().mode();
+            (mode & 0o444) != 0 // check if file has read permission
+        };
+
+        #[cfg(windows)]
+        let is_readable = {
+            !metadata.permissions().readonly() // on Windows, check if file is not readonly
+        };
+
+        is_readable
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -89,7 +89,18 @@ impl Utils {
 
             // Days in each month (adjust for leap year)
             let month_days = [
-                31, if is_leap_year(year) { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+                31,
+                if is_leap_year(year) { 29 } else { 28 },
+                31,
+                30,
+                31,
+                30,
+                31,
+                31,
+                30,
+                31,
+                30,
+                31,
             ];
 
             let mut month = 0;
@@ -143,7 +154,18 @@ impl Utils {
 
             // Days in each month (adjust for leap year)
             let month_days = [
-                31, if is_leap_year(year) { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31,
+                31,
+                if is_leap_year(year) { 29 } else { 28 },
+                31,
+                30,
+                31,
+                30,
+                31,
+                31,
+                30,
+                31,
+                30,
+                31,
             ];
             let month_names = [
                 "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
@@ -163,7 +185,7 @@ impl Utils {
 
             if m <= 2 {
                 m += 12; // Jan, Feb become 13, 14
-                y -= 1;  // Adjust year
+                y -= 1; // Adjust year
             }
 
             let k: i32 = y % 100;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,6 @@
 use std::env;
 use std::fs::{self, Metadata, ReadDir};
+use std::net::TcpStream;
 use std::path::{Component, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -269,5 +270,12 @@ impl Utils {
             let prettified = path.to_str().unwrap().replace('\\', "/");
 
         prettified
+    }
+
+    pub fn get_peer_ip(stream: &TcpStream) -> String {
+        match stream.peer_addr() {
+            Ok(addr) => addr.ip().to_string(),
+            Err(_) => "unknown".to_string(),
+        }
     }
 }

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -6,13 +6,13 @@ mod tests {
     use std::path::PathBuf;
 
     fn get_host() -> String {
-        let host = if cfg!(target_family = "windows") {
+        
+
+        if cfg!(target_family = "windows") {
             "127.0.0.1".to_string()
         } else {
             "0.0.0.0".to_string()
-        };
-
-        host
+        }
     }
 
     /// Test case for when no arguments are passed.


### PR DESCRIPTION
# Changes from `refactor/basic-improvements` to `develop`

## Commits Overview: 

- df11644 **refactor(): extract connection logging into dedicated method in server.rs**
- 2c976af **feat(): add log_source_ip to log client IP for incoming connections in utils.rs**
- 8a859d1 **refactor(): improve code clarity using clippy**
- 79bd31b **refactor(): use for debug prettified path while serving file in response.rs**
- e57098b **refactor(): redefine response meta access level**
  > as size is accessed in server.rs, it's not a meta anymore and no need to be private.
removed pub from _need_stream and _is_compiled as they are for response internal usage only.
- f5dedc8 **refactor(): improve file path handling and logging in response.rs**
- 60fc5dd **feat(): add path_prettifier for system-specific formatting to utils.rs**
- 780d7f9 **refactor(): format codebase using cargo fmt**
- 048819d **fix(): use utility function for file readability check in response.rs**
- 3e30edf **feat(utils): add platform-specific file readability check**
- 6e9794d **refactor(): normalize path separators better for cross-platform support**
  > this is mainly for display purpose as it was perfectly working before this commit