### PR TITLE
Changes from `patch/nameless-and-extensionless-files` to `develop`

### DIFF
--- a/src/core/server/http.rs
+++ b/src/core/server/http.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum HttpVersion {
     Http10,
     Http11,

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -325,6 +325,13 @@ impl Response {
         self.headers
             .add("Content-Length".to_string(), self.size.to_string());
 
+        // only for http/1.1
+        if self.http_version == HttpVersion::Http11 {
+            // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Connection
+            self.headers
+                .add("Connection".to_string(), "close".to_string());
+        }
+
         if self._is_compiled {
             if self.body.is_empty() {
                 Logger::error("[Response] Body is empty while expecting compiled content");

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -325,8 +325,8 @@ impl Response {
         self.headers
             .add("Content-Length".to_string(), self.size.to_string());
 
-        // only for http/1.1
-        if self.http_version == HttpVersion::Http11 {
+        // only for http/1.X
+        if self.http_version == HttpVersion::Http10 || self.http_version == HttpVersion::Http11 {
             // @see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Connection
             self.headers
                 .add("Connection".to_string(), "close".to_string());

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -109,7 +109,7 @@ impl Response {
 
         match File::open(&path) {
             Ok(_file) => {
-                let extension = path.extension().unwrap().to_str().unwrap();
+                let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
 
                 let file_type = FileType::from_extension(extension)
                     .unwrap_or_else(|| FileType::new("bin", "application/octet-stream"));
@@ -144,6 +144,15 @@ impl Response {
 
                 self.status_code = HttpStatus::Ok;
                 self.headers.clear();
+
+                // @see: https://stackoverflow.com/a/28652339/13158370
+                if extension == "" {
+                    Logger::debug("[Response] No extension found, not using content type");
+                    return;
+                }
+
+                Logger::debug(format!("[Response] Found extension: {}", extension).as_str());
+
                 self.headers.add(
                     "Content-Type".to_string(),
                     file_type.content_type.to_string(),

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -162,7 +162,10 @@ impl Response {
                     content_disposition.to_string(),
                 );
             }
-            Err(_) => self.serve_error_response(HttpStatus::NotFound),
+            Err(_) => {
+                Logger::error(format!("[Response] File not found: {}", display_path).as_str());
+                self.serve_error_response(HttpStatus::NotFound);
+            }
         }
     }
 

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -255,6 +255,8 @@ impl Response {
     }
 
     fn serve_error_response(&mut self, status: HttpStatus) {
+        self._is_compiled = true; // mark as compiled to avoid streaming
+
         let mut params = HashMap::new();
         params.insert("status_code".to_string(), status.to_code().to_string());
         params.insert("status_text".to_string(), status.to_message().to_string());

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -375,6 +375,8 @@ impl Response {
             }
         };
 
+        stream.flush()?;
+
         Ok(())
     }
 

--- a/src/core/server/response.rs
+++ b/src/core/server/response.rs
@@ -9,7 +9,7 @@ use std::cmp::min;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Error, Read, Seek, SeekFrom, Write};
-use std::net::TcpStream;
+use std::net::{Shutdown, TcpStream};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug)]
@@ -378,6 +378,8 @@ impl Response {
         };
 
         stream.flush()?;
+
+        stream.shutdown(Shutdown::Both)?;
 
         Ok(())
     }


### PR DESCRIPTION
# Changes from `patch/nameless-and-extensionless-files` to `develop`

## Commits Overview: 

- 04b5324 **refactor(): extend support for Connection header to HTTP/1.0 from 5fe71346**
- 5fe7134 **refactor(): add Connection header for HTTP/1.1 response**
  > add traits PartialEq, Eq and Hash to HttpVersion enum
- a682a5d **refactor(): shutdown TCP stream after response handling**
- f14e878 **refactor(): mark response as compiled to avoid streaming in error handling**
- 6d839da **refactor(): ensure stream is flushed after response handling**
- 24f6dc4 **refactor(): log error message for file not found in response handling**
- 10cd74b **refactor(): handle extensionless files in response handling**