### PR TITLE
Changes from `refactor/config-and-variables` to `develop`

### DIFF
--- a/.katana.example
+++ b/.katana.example
@@ -23,7 +23,7 @@ host = "127.0.0.1"
 port = 8081
 
 # Directory to serve static files from
-root_dir = "public"
+document_root = "public"
 
 # Number of worker threads for handling requests
 worker = 4

--- a/.katana.example
+++ b/.katana.example
@@ -20,7 +20,7 @@
 host = "127.0.0.1"
 
 # Port number to run the server on
-port = 8081
+port = 8080
 
 # Directory to serve static files from
 document_root = "public"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,11 +17,11 @@ FROM alpine:latest
 
 ENV KATANA_HOST=0.0.0.0
 ENV KATANA_PORT=8080
-ENV KATANA_ROOT=public
+ENV KATANA_DOCUMENT_ROOT=public
 ENV KATANA_WORKER=4
 
 WORKDIR /app
 
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/katana ./
 
-CMD ["sh", "-c","./katana", "--host", "${HOST}", "--port", "${PORT}", "--root-dir", "${ROOT_DIR}", "--worker", "${WORKER}"]
+CMD ["sh", "-c","./katana", "--host", "${HOST}", "--port", "${PORT}", "--document-root", "${KATANA_DOCUMENT_ROOT}", "--worker", "${WORKER}"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ ENV KATANA_HOST=0.0.0.0
 ENV KATANA_PORT=8080
 ENV KATANA_DOCUMENT_ROOT=public
 ENV KATANA_WORKER=4
+ENV KATANA_LOG_LEVEL=info
 
 WORKDIR /app
 
 COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/katana ./
 
-CMD ["sh", "-c","./katana", "--host", "${HOST}", "--port", "${PORT}", "--document-root", "${KATANA_DOCUMENT_ROOT}", "--worker", "${WORKER}"]
+CMD ["./katana"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,10 @@ RUN cargo build --release --target=x86_64-unknown-linux-musl
 # Stage 2: Runtime
 FROM alpine:latest
 
-ENV HOST=0.0.0.0
-ENV PORT=8080
-ENV ROOT_DIR=public
-ENV WORKER=4
+ENV KATANA_HOST=0.0.0.0
+ENV KATANA_PORT=8080
+ENV KATANA_ROOT=public
+ENV KATANA_WORKER=4
 
 WORKDIR /app
 

--- a/src/core/config/arg.rs
+++ b/src/core/config/arg.rs
@@ -11,7 +11,7 @@ pub fn load_args() -> Config {
 pub fn parse_args(args: Vec<String>) -> Config {
     let mut host = None;
     let mut port = None;
-    let mut root_dir = None;
+    let mut document_root = None;
     let mut worker = None;
     let mut log_level = None;
 
@@ -24,9 +24,9 @@ pub fn parse_args(args: Vec<String>) -> Config {
                     i += 1;
                 }
             }
-            "--dir" => {
+            "--document-root" => {
                 if i + 1 < args.len() {
-                    root_dir = Some(PathBuf::from(&args[i + 1]));
+                    document_root = Some(PathBuf::from(&args[i + 1]));
                     i += 1;
                 }
             }
@@ -56,7 +56,7 @@ pub fn parse_args(args: Vec<String>) -> Config {
     Config {
         host: host.unwrap_or_default(),
         port: port.unwrap_or_default(),
-        root_dir: root_dir.unwrap_or_default(),
+        document_root: document_root.unwrap_or_default(),
         worker: worker.unwrap_or_default(),
         log_level: log_level.unwrap_or(LogLevel::INFO),
     }

--- a/src/core/config/arg.rs
+++ b/src/core/config/arg.rs
@@ -54,6 +54,7 @@ pub fn parse_args(args: Vec<String>) -> Config {
     }
 
     Config {
+        _source: crate::core::config::config::ConfigSource::Args,
         host: host.unwrap_or_default(),
         port: port.unwrap_or_default(),
         document_root: document_root.unwrap_or_default(),

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -28,7 +28,7 @@ impl Config {
             Self::load_args(),
         ];
 
-        let config = configs.into_iter().fold(Config::default(), |acc, curr| {
+        let config = configs.into_iter().fold(Self::default(), |acc, curr| {
             Config {
                 _source: curr._source,
                 host: if curr.host.is_empty() { acc.host } else { curr.host },
@@ -50,7 +50,7 @@ impl Config {
     }
 
     fn default() -> Self {
-        super::default::DefaultConfig::as_config()
+        super::default::load_default()
     }
 
     pub fn load_args() -> Self {

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -5,7 +5,7 @@ use crate::core::utils::logger::LogLevel;
 pub struct Config {
     pub host: String,
     pub port: u16,
-    pub root_dir: PathBuf,
+    pub document_root: PathBuf,
     pub worker: i32,
     pub log_level: LogLevel,
 }
@@ -23,7 +23,7 @@ impl Config {
             Config {
                 host: if curr.host.is_empty() { acc.host } else { curr.host },
                 port: if curr.port == 0 { acc.port } else { curr.port },
-                root_dir: if curr.root_dir.as_os_str().is_empty() { acc.root_dir } else { curr.root_dir },
+                document_root: if curr.document_root.as_os_str().is_empty() { acc.document_root } else { curr.document_root },
                 worker: if curr.worker <= 0 { acc.worker } else { curr.worker },
                 log_level: curr.log_level,
             }

--- a/src/core/config/default.rs
+++ b/src/core/config/default.rs
@@ -29,3 +29,7 @@ impl DefaultConfig {
         }
     }
 }
+
+pub fn load_default() -> Config {
+    DefaultConfig::as_config()
+}

--- a/src/core/config/default.rs
+++ b/src/core/config/default.rs
@@ -14,6 +14,7 @@ impl DefaultConfig {
 
     pub fn as_config() -> Config {
         Config {
+            _source: crate::core::config::config::ConfigSource::Default,
             host: None::<String>.unwrap_or_else(|| {
                 if cfg!(target_family = "windows") {
                     Self::HOST_WINDOWS.to_string()

--- a/src/core/config/default.rs
+++ b/src/core/config/default.rs
@@ -8,7 +8,7 @@ impl DefaultConfig {
     pub const HOST_WINDOWS: &'static str = "127.0.0.1";
     pub const HOST_UNIX: &'static str = "0.0.0.0";
     pub const PORT: u16 = 8080;
-    pub const ROOT_DIR: &'static str = "public";
+    pub const DOCUMENT_ROOT: &'static str = "public";
     pub const WORKER: i32 = 4;
     pub const LOG_LEVEL: LogLevel = LogLevel::INFO;
 
@@ -22,7 +22,7 @@ impl DefaultConfig {
                 }
             }),
             port: None::<u16>.unwrap_or(Self::PORT),
-            root_dir: None::<PathBuf>.unwrap_or_else(|| PathBuf::from(Self::ROOT_DIR)),
+            document_root: None::<PathBuf>.unwrap_or_else(|| PathBuf::from(Self::DOCUMENT_ROOT)),
             worker: None::<i32>.unwrap_or(Self::WORKER),
             log_level: None::<LogLevel>.unwrap_or(Self::LOG_LEVEL),
         }

--- a/src/core/config/env.rs
+++ b/src/core/config/env.rs
@@ -12,7 +12,7 @@ pub fn load_env() -> Config {
         .ok()
         .and_then(|p| p.parse().ok());
 
-    let root_dir = env::var("KATANA_ROOT")
+    let document_root = env::var("KATANA_DOCUMENT_ROOT")
         .map(PathBuf::from)
         .ok();
 
@@ -27,7 +27,7 @@ pub fn load_env() -> Config {
     Config {
         host: host.unwrap_or_default(),
         port: port.unwrap_or_default(),
-        root_dir: root_dir.unwrap_or_default(),
+        document_root: document_root.unwrap_or_default(),
         worker: worker.unwrap_or_default(),
         log_level: log_level.unwrap_or(LogLevel::DEBUG),
     }

--- a/src/core/config/env.rs
+++ b/src/core/config/env.rs
@@ -25,6 +25,7 @@ pub fn load_env() -> Config {
         .and_then(|l| LogLevel::from_str(&l.to_uppercase()));
 
     Config {
+        _source: crate::core::config::config::ConfigSource::Env,
         host: host.unwrap_or_default(),
         port: port.unwrap_or_default(),
         document_root: document_root.unwrap_or_default(),

--- a/src/core/config/file.rs
+++ b/src/core/config/file.rs
@@ -85,6 +85,7 @@ pub fn load_file() -> Config {
     };
 
     Config {
+        _source: crate::core::config::config::ConfigSource::File,
         host,
         port,
         document_root,

--- a/src/core/config/file.rs
+++ b/src/core/config/file.rs
@@ -7,8 +7,8 @@ use crate::core::utils::toml::{TomlParser, TomlValue};
 
 pub fn load_file() -> Config {
     // Use the root directory of the project
-    let root_dir = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    let katana_file_path = root_dir.join(".katana");
+    let document_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let katana_file_path = document_root.join(".katana");
 
     let mut parser = TomlParser::new();
 
@@ -56,13 +56,13 @@ pub fn load_file() -> Config {
         DefaultConfig::PORT
     };
 
-    let root_dir = if let Some(TomlValue::Table(table)) = katana {
-        match table.get("root_dir") {
+    let document_root = if let Some(TomlValue::Table(table)) = katana {
+        match table.get("document_root") {
             Some(TomlValue::String(dir)) => PathBuf::from(dir),
-            _ => PathBuf::from(DefaultConfig::ROOT_DIR),
+            _ => PathBuf::from(DefaultConfig::DOCUMENT_ROOT),
         }
     } else {
-        PathBuf::from(DefaultConfig::ROOT_DIR)
+        PathBuf::from(DefaultConfig::DOCUMENT_ROOT)
     };
 
     let worker = if let Some(TomlValue::Table(table)) = katana {
@@ -87,7 +87,7 @@ pub fn load_file() -> Config {
     Config {
         host,
         port,
-        root_dir,
+        document_root,
         worker,
         log_level,
     }

--- a/src/core/server/server.rs
+++ b/src/core/server/server.rs
@@ -76,7 +76,7 @@ impl Server {
 
     pub fn handle_response(&self, request: Request, mut stream: &mut TcpStream) {
         if let Some(mut response) = Response::new(request, self.templates.to_owned()) {
-            response.serve(&self.config.root_dir);
+            response.serve(&self.config.document_root);
             self.method_handle(&mut response);
             self.server_transformation(&mut response);
 

--- a/tests/config_test.rs
+++ b/tests/config_test.rs
@@ -27,7 +27,7 @@ mod tests {
 
         assert_eq!(config.host, get_host());
         assert_eq!(config.port, 8080);
-        assert_eq!(config.root_dir, PathBuf::from("public"));
+        assert_eq!(config.document_root, PathBuf::from("public"));
         assert_eq!(config.worker, 4);
     }
 
@@ -43,7 +43,7 @@ mod tests {
 
         assert_eq!(config.host, get_host());
         assert_eq!(config.port, 8080); // Default port
-        assert_eq!(config.root_dir, PathBuf::from("public"));
+        assert_eq!(config.document_root, PathBuf::from("public"));
         assert_eq!(config.worker, 4);
     }
 
@@ -55,7 +55,7 @@ mod tests {
 
         assert_eq!(config.host, get_host());
         assert_eq!(config.port, 8080); // Default port
-        assert_eq!(config.root_dir, PathBuf::from("public"));
+        assert_eq!(config.document_root, PathBuf::from("public"));
         assert_eq!(config.worker, 4);
     }
 
@@ -68,7 +68,7 @@ mod tests {
 
         assert_eq!(config.host, get_host());
         assert_eq!(config.port, 8080);
-        assert_eq!(config.root_dir, PathBuf::from("a".repeat(300)));
+        assert_eq!(config.document_root, PathBuf::from("a".repeat(300)));
         assert_eq!(config.worker, 4);
     }
 
@@ -84,7 +84,7 @@ mod tests {
 
         assert_eq!(config.host, "256.256.256.256"); // Host accepts any string, no validation
         assert_eq!(config.port, 8080);
-        assert_eq!(config.root_dir, PathBuf::from("public"));
+        assert_eq!(config.document_root, PathBuf::from("public"));
         assert_eq!(config.worker, 4);
     }
 
@@ -100,7 +100,7 @@ mod tests {
 
         assert_eq!(config.host, get_host()); // Default should still be used
         assert_eq!(config.port, 8080); // Default should still be used
-        assert_eq!(config.root_dir, PathBuf::from("public")); // Default should still be used
+        assert_eq!(config.document_root, PathBuf::from("public")); // Default should still be used
         assert_eq!(config.worker, 4);
     }
 
@@ -118,7 +118,7 @@ mod tests {
 
         assert_eq!(config.host, get_host());
         assert_eq!(config.port, 5000); // Last port specified should be used
-        assert_eq!(config.root_dir, PathBuf::from("public"));
+        assert_eq!(config.document_root, PathBuf::from("public"));
         assert_eq!(config.worker, 4);
     }
 


### PR DESCRIPTION
# Changes from `refactor/config-and-variables` to `develop`

## Commits Overview: 

- 26fc3e2 **chore(): add log level and simplify command in Dockerfile**
- 32d448e **refactor(): change default port number from 8081 to 8080 for in .katana.example**
- e9eb0e2 **refactor(): simplify configs loading from file by using default**
- e4c524f **refactor(): update default configuration loading method to keep consistency**
- f30460e **feat(): add source tracking to Config struct for improved clarity**
- 04fead8 **refactor(): rename root_dir to document_root for consistency**
- f3aaa59 **chore(): rename environment variables for clarity and consistency**