### PR TITLE
feat(args): add --help/-h CLI flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "katana"
 version = "0.1.0"
 edition = "2021"
+authors = ["Judicaël AHYI <ludndev@gmail.com>"]
 
 [lib]
 name = "katana"

--- a/src/core/config/arg.rs
+++ b/src/core/config/arg.rs
@@ -9,6 +9,7 @@ pub fn load_args() -> Config {
 }
 
 pub fn parse_args(args: Vec<String>) -> Config {
+    let mut display_help = false;
     let mut host = None;
     let mut port = None;
     let mut document_root = None;
@@ -18,6 +19,9 @@ pub fn parse_args(args: Vec<String>) -> Config {
     let mut i = 1;
     while i < args.len() {
         match args[i].as_str() {
+            "--help" | "-h" => {
+                display_help = true;
+            }
             "--port" => {
                 if i + 1 < args.len() {
                     port = args[i + 1].parse().ok();
@@ -54,6 +58,7 @@ pub fn parse_args(args: Vec<String>) -> Config {
     }
 
     Config {
+        display_help,
         _source: crate::core::config::config::ConfigSource::Args,
         host: host.unwrap_or_default(),
         port: port.unwrap_or_default(),

--- a/src/core/config/config.rs
+++ b/src/core/config/config.rs
@@ -11,6 +11,7 @@ pub enum ConfigSource {
 
 #[derive(Debug, Clone)]
 pub struct Config {
+    pub display_help: bool,
     pub _source: ConfigSource,
     pub host: String,
     pub port: u16,
@@ -30,6 +31,7 @@ impl Config {
 
         let config = configs.into_iter().fold(Self::default(), |acc, curr| {
             Config {
+                display_help: acc.display_help || curr.display_help,
                 _source: curr._source,
                 host: if curr.host.is_empty() { acc.host } else { curr.host },
                 port: if curr.port == 0 { acc.port } else { curr.port },

--- a/src/core/config/default.rs
+++ b/src/core/config/default.rs
@@ -14,6 +14,7 @@ impl DefaultConfig {
 
     pub fn as_config() -> Config {
         Config {
+            display_help: false,
             _source: crate::core::config::config::ConfigSource::Default,
             host: None::<String>.unwrap_or_else(|| {
                 if cfg!(target_family = "windows") {

--- a/src/core/config/env.rs
+++ b/src/core/config/env.rs
@@ -25,6 +25,7 @@ pub fn load_env() -> Config {
         .and_then(|l| LogLevel::from_str(&l.to_uppercase()));
 
     Config {
+        display_help: false,
         _source: crate::core::config::config::ConfigSource::Env,
         host: host.unwrap_or_default(),
         port: port.unwrap_or_default(),

--- a/src/core/config/file.rs
+++ b/src/core/config/file.rs
@@ -60,6 +60,7 @@ pub fn load_file() -> Config {
     };
 
     Config {
+        display_help: false,
         _source: crate::core::config::config::ConfigSource::File,
         host,
         port,

--- a/src/core/resources/templates.rs
+++ b/src/core/resources/templates.rs
@@ -6,6 +6,7 @@ pub enum TemplatesPage {
     BANNER,
     ERROR,
     DIRECTORY,
+    HELP,
 }
 
 #[derive(Debug, Clone)]
@@ -13,6 +14,7 @@ pub struct Templates {
     pub banner: String,
     pub error: String,
     pub directory: String,
+    pub help: String,
 }
 
 macro_rules! include_template {
@@ -28,6 +30,7 @@ impl Templates {
             banner: String::from(include_template!("/banner.txt")),
             error: String::from(include_template!("/error.html")),
             directory: String::from(include_template!("/directory.html")),
+            help: String::from(include_template!("/help.txt")),
         };
         Logger::debug("[Templates] Template files loaded successfully");
         templates
@@ -47,6 +50,7 @@ impl Templates {
             TemplatesPage::BANNER => Some(templates.banner),
             TemplatesPage::ERROR => Some(templates.error),
             TemplatesPage::DIRECTORY => Some(templates.directory),
+            TemplatesPage::HELP => Some(templates.help),
         };
 
         if result.is_none() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ impl Katana {
     }
 
     pub fn start(&self) {
+        self.display_help_if_needed();
         self.show_banner();
         let server = Server::new(self.config.to_owned(), self.templates.to_owned());
         Logger::info(format!("Server starting on {}", server.addr_with_protocol()).as_str());
@@ -39,5 +40,16 @@ impl Katana {
             format!("{: >1$}", Server::version(), 67),
         );
         println!("{}", self.templates.render(TemplatesPage::BANNER, params));
+    }
+
+    fn display_help_if_needed(&self) {
+        if self.config.display_help {
+            let mut params = HashMap::new();
+            params.insert("author".to_string(), env!("CARGO_PKG_AUTHORS").to_string());
+            params.insert("binary_name".to_string(), env!("CARGO_PKG_NAME").to_string());
+
+            println!("{}", self.templates.render(TemplatesPage::HELP, params));
+            std::process::exit(0);
+        }
     }
 }

--- a/templates/help.txt
+++ b/templates/help.txt
@@ -1,0 +1,13 @@
+
+Author: {{author}}
+
+Usage:
+{{binary_name}} [OPTIONS]
+
+Options:
+  --help | -h             Show this help message and exit
+  --port <PORT>           Set the port to listen on (default: 8080)
+  --document-root <PATH>  Set the document root directory (default: ./public)
+  --host <HOST>           Set the host to bind to (default: 0.0.0.0, or 127.0.0.1 on Windows)
+  --worker <NUM>          Set the number of worker threads (default: 4)
+  --log-level <LEVEL>     Set the log level (DEBUG, INFO, WARN, ERROR) (default: INFO)


### PR DESCRIPTION
## Summary
- Adds `--help`/`-h` CLI flag that renders `templates/help.txt` and exits before the server starts.
- Introduces `display_help` on `Config` (populated from args) and `authors` in `Cargo.toml` (used in the template).
- Help runs **before** the banner, so `katana --help` outputs only the usage text.

## Notes
Rebased onto current `develop` and squashed from 4 commits into 1. No conflicts.

Polish vs. the original branch:
- Fixed wrong default for `--host` in `help.txt` (was listed as `8080`; now `0.0.0.0`, Windows `127.0.0.1`).
- Moved `display_help_if_needed()` before `show_banner()` so `--help` doesn't print the ASCII banner first.
- Renamed `_display_help` → `display_help` (underscore prefix was reserved for internal metadata like `_source`).
- Dropped redundant `format!("{}", env!(...))` wrappers.
- Added trailing newline to `help.txt`.

## Test plan
- [x] `cargo build --bin katana` compiles cleanly (only pre-existing warnings).
- [x] `cargo run --bin katana -- --help` prints the help block and exits 0, no banner.
- [ ] `cargo run --bin katana -- -h` behaves identically.
- [ ] Running without `--help` still starts the server as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)